### PR TITLE
Add support for command line interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 **/__pycache__/
 .cache/
+*.egg-info/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools >= 61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+dynamic = ["version"]
+name  = "slimgen"
+dependencies = [
+    "typer"
+]
+
+[project.scripts]
+slimgen = "slimgen.cli:app"
+
+[project.entry-points."pipx.run"]
+slimgen = "slimgen.cli:app"

--- a/src/slimgen/__main__.py
+++ b/src/slimgen/__main__.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+if __name__ == "__main__":
+    from slimgen.cli import app
+    app()

--- a/src/slimgen/cli.py
+++ b/src/slimgen/cli.py
@@ -1,0 +1,11 @@
+import typer
+
+from .main import main
+
+
+app = typer.Typer()
+app.command()(main)
+
+
+if __name__ == "__main__":
+    app()

--- a/src/slimgen/main.py
+++ b/src/slimgen/main.py
@@ -1,0 +1,5 @@
+import typer
+from typing_extensions import Annotated
+
+def main(arg1: Annotated[str, typer.Argument(help="idk")] = ""):
+    print('Slimgen executed!')


### PR DESCRIPTION
Adds necessary files pyproject.toml and src/slimgen/ directory. Allows the project to be installed from a package index and accessed from the terminal with the command `slimgen`. 